### PR TITLE
fix: dynamically extend year ranges to include current year

### DIFF
--- a/AnimeDatasetCollector/fetch_data.py
+++ b/AnimeDatasetCollector/fetch_data.py
@@ -549,8 +549,12 @@ def fetch_all_anime(test_mode=False):
             (2016, 2016), (2017, 2017), (2018, 2018),  # Recent anime (many entries per year)
             (2019, 2019), (2020, 2020), (2021, 2021),  # Very recent anime
             (2022, 2022), (2023, 2023), (2024, 2024),  # Current anime
-            (2025, 2025)  # Upcoming anime
+            (2025, 2025),
         ]
+        # Dynamically add any years after 2025 up to and including the current year
+        current_year = datetime.now().year
+        for y in range(2026, current_year + 1):
+            year_ranges.append((y, y))
     
     all_anime = []
     


### PR DESCRIPTION
Hi! Thanks for putting this dataset up, it's been very helpful for data analysis and bulk title fuzzy matching. However it looks like the date-range batching logic needs to be updated. The current dataset only includes seasons in the hard-coded ranges up to 2025: so currently winter and spring 2026 anime are missing. This PR extends the year ranges so it should include all years going forward.